### PR TITLE
Reset long break session count at midnight

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A clean, modern iOS Pomodoro timer app built with Swift and SwiftUI. Boost your 
 - **🔔 Push Notifications**: Get notified when sessions complete (even when app is closed)
 - **🔊 Sound Alerts**: Optional audio notifications for session completion
 - **💾 Persistent State**: App remembers your progress if closed unexpectedly
+- **🗓️ Daily Reset**: Completed session counter resets every midnight to keep long breaks aligned with each day
 
 ### Analytics & Tracking
 - **📊 Daily Statistics**: Track today's completed Pomodoros and total focus time


### PR DESCRIPTION
## Summary
- reset completed Pomodoro session counter when the calendar day changes
- update README to document daily reset behavior

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68acbcfe7aa4832a97428c70d1842a7f